### PR TITLE
Remove unnecessary extension.

### DIFF
--- a/lib/resque-rails/railtie.rb
+++ b/lib/resque-rails/railtie.rb
@@ -1,6 +1,5 @@
 module Resque::Rails
   class Railtie < Rails::Railtie
-    extend Rake::DSL
 
     initializer 'resque.set_config' do
       Resque.redis ||= 'localhost:6379'
@@ -10,5 +9,7 @@ module Resque::Rails
       require 'resque/tasks'
       task "resque:setup" => :environment
     end
+
   end
 end
+


### PR DESCRIPTION
Extending the Rake DSL is not necessary.

@jugyo, thank you for your straightforward `rescue-rails`. The present version did not work immediately for me, though, and I had to remove the Rake DSL extension to make it work. Here is the commit---just let me know if I have missed something.
